### PR TITLE
feat:예산설정 및 설계 API 생성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { CategorieModule } from './categorie/categorie.module';
+import { BudgetModule } from './budget/budget.module';
 @Module({
   imports: [
     AuthModule,
@@ -25,6 +26,7 @@ import { CategorieModule } from './categorie/categorie.module';
       }),
     }),
     CategorieModule,
+    BudgetModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
+import { CategorieModule } from './categorie/categorie.module';
 @Module({
   imports: [
     AuthModule,
@@ -23,6 +24,7 @@ import { AuthModule } from './auth/auth.module';
         logging: true,
       }),
     }),
+    CategorieModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/entities/auth.entity.ts
+++ b/src/auth/entities/auth.entity.ts
@@ -1,3 +1,4 @@
+import { Budget } from '../../budget/entities/budget.entity';
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -5,6 +6,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Unique,
+  OneToMany,
 } from 'typeorm';
 
 @Entity()
@@ -24,4 +26,7 @@ export class User {
 
   @UpdateDateColumn()
   updated_at: Date;
+
+  @OneToMany(() => Budget, (budget) => budget.user, { cascade: true })
+  budget: Budget;
 }

--- a/src/budget/budget.controller.spec.ts
+++ b/src/budget/budget.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BudgetController } from './budget.controller';
+import { BudgetService } from './budget.service';
+
+describe('BudgetController', () => {
+  let controller: BudgetController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BudgetController],
+      providers: [BudgetService],
+    }).compile();
+
+    controller = module.get<BudgetController>(BudgetController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/budget/budget.controller.ts
+++ b/src/budget/budget.controller.ts
@@ -1,11 +1,19 @@
-import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UseGuards,
+  Patch,
+  Param,
+} from '@nestjs/common';
 import { BudgetService } from './budget.service';
 import { AuthGuard } from '@nestjs/passport';
 import { GetUser } from 'src/auth/deco/get-user.decorator';
 import { User } from 'src/auth/entities/auth.entity';
 import { CreateBudgetDto } from './dto/create-budget.dto';
+import { UpdateBudgetDto } from './dto/update-budget.dto';
 
-@Controller('api/categorie')
+@Controller('api')
 @UseGuards(AuthGuard())
 export class BudgetController {
   constructor(private readonly budgetService: BudgetService) {}
@@ -19,5 +27,28 @@ export class BudgetController {
     return {
       message: '예산이 설정되었습니다 ',
     };
+  }
+
+  @Patch('budget/:id')
+  async modifyBudget(
+    @GetUser() user: User,
+    @Param('id') id: number,
+    @Body() updateBudgetDto: UpdateBudgetDto,
+  ): Promise<any> {
+    await this.budgetService.updateBudget(user, id, updateBudgetDto);
+    return {
+      message: '수정이 완료되었습니다.',
+    };
+  }
+
+  @Post('budget/auto-distribute')
+  async autoDistributeBudget(
+    @GetUser() user: User,
+    @Body('amount') amount: number,
+  ): Promise<any> {
+    const recommendedBudget = await this.budgetService.autoDistributeBudget(
+      amount,
+    );
+    return recommendedBudget;
   }
 }

--- a/src/budget/budget.controller.ts
+++ b/src/budget/budget.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { BudgetService } from './budget.service';
+import { AuthGuard } from '@nestjs/passport';
+import { GetUser } from 'src/auth/deco/get-user.decorator';
+import { User } from 'src/auth/entities/auth.entity';
+import { CreateBudgetDto } from './dto/create-budget.dto';
+
+@Controller('api/categorie')
+@UseGuards(AuthGuard())
+export class BudgetController {
+  constructor(private readonly budgetService: BudgetService) {}
+
+  @Post('budget')
+  async setBudget(
+    @GetUser() user: User,
+    @Body() createBudgetDto: CreateBudgetDto,
+  ): Promise<any> {
+    await this.budgetService.saveBudget(user, createBudgetDto);
+    return {
+      message: '예산이 설정되었습니다 ',
+    };
+  }
+}

--- a/src/budget/budget.module.ts
+++ b/src/budget/budget.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { BudgetService } from './budget.service';
+import { BudgetController } from './budget.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Budget } from './entities/budget.entity';
+import { PassportModule } from '@nestjs/passport';
+import { CategorieModule } from 'src/categorie/categorie.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Budget]),
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    CategorieModule,
+  ],
+  controllers: [BudgetController],
+  providers: [BudgetService],
+})
+export class BudgetModule {}

--- a/src/budget/budget.service.spec.ts
+++ b/src/budget/budget.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BudgetService } from './budget.service';
+
+describe('BudgetService', () => {
+  let service: BudgetService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BudgetService],
+    }).compile();
+
+    service = module.get<BudgetService>(BudgetService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/budget/budget.service.ts
+++ b/src/budget/budget.service.ts
@@ -3,9 +3,10 @@ import { CreateBudgetDto } from './dto/create-budget.dto';
 import { Budget } from './entities/budget.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from 'src/auth/entities/auth.entity';
-import { Repository } from 'typeorm';
+import { Repository, FindOneOptions } from 'typeorm';
 import { CategorieService } from 'src/categorie/categorie.service';
 import { Categorie } from 'src/categorie/entities/categorie.entity';
+import { UpdateBudgetDto } from './dto/update-budget.dto';
 
 @Injectable()
 export class BudgetService {
@@ -14,6 +15,7 @@ export class BudgetService {
     private budgetRepository: Repository<Budget>,
     private categorieService: CategorieService,
   ) {}
+
   async saveBudget(
     user: User,
     createBudgetDto: CreateBudgetDto,
@@ -32,15 +34,104 @@ export class BudgetService {
     await this.save(user, categorieFind, createBudgetDto);
   }
 
+  async updateBudget(
+    user: User,
+    id: number,
+    updateBudgetDto: UpdateBudgetDto,
+  ): Promise<void> {
+    const budgetFind = await this.findOne({
+      where: {
+        id,
+        user: { id: user.id },
+      },
+    });
+
+    if (!budgetFind) {
+      throw new HttpException(
+        '예산 설정을 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    await this.update(budgetFind, updateBudgetDto);
+  }
+
+  async autoDistributeBudget(
+    amount: number,
+  ): Promise<{ [category: string]: number }> {
+    const totalBudgets = await this.getTotalBudgets();
+    const totalBudget = this.calculateTotalBudget(totalBudgets);
+    const recommendedBudget = this.calculateRecommendedBudget(
+      totalBudgets,
+      totalBudget,
+      amount,
+    );
+    return recommendedBudget;
+  }
+
+  async getTotalBudgets() {
+    return await this.budgetRepository
+      .createQueryBuilder('budget')
+      .leftJoin('budget.categorie', 'categorie')
+      .select('categorie.title', 'category')
+      .addSelect('SUM(budget.amount)', 'amount')
+      .groupBy('categorie.title')
+      .getRawMany();
+  }
+
+  calculateTotalBudget(totalBudgets) {
+    return totalBudgets.reduce(
+      (total, categoryTotal) => total + parseFloat(categoryTotal.amount),
+      0,
+    );
+  }
+
+  calculateRecommendedBudget(totalBudgets, totalBudget, amount) {
+    const recommendedBudget = {};
+
+    totalBudgets.forEach((categoryTotal) => {
+      const category = categoryTotal.category;
+      const categoryTotalAmount = parseFloat(categoryTotal.amount);
+      const categoryPercentage = Math.round(
+        (categoryTotalAmount / totalBudget) * 100,
+      );
+      recommendedBudget[category] = categoryPercentage * amount;
+    });
+
+    return recommendedBudget;
+  }
+
+  async find(options: FindOneOptions<Budget>): Promise<Budget[]> {
+    return await this.budgetRepository.find(options);
+  }
+
+  async findOne(options: FindOneOptions<Budget>): Promise<Budget> {
+    return await this.budgetRepository.findOne(options);
+  }
+
   async save(
     user: User,
     categorieFind: Categorie,
     createBudgetDto: CreateBudgetDto,
-  ) {
+  ): Promise<void> {
     await this.budgetRepository.save({
       user: { id: user.id },
       categorie: { id: categorieFind.id },
       amount: createBudgetDto.amount,
     });
+  }
+
+  async update(
+    budgetFind: Budget,
+    updateBudgetDto: UpdateBudgetDto,
+  ): Promise<void> {
+    await this.budgetRepository
+      .createQueryBuilder()
+      .update(Budget)
+      .set({
+        amount: updateBudgetDto.amount,
+      })
+      .where('id = :id', { id: budgetFind.id })
+      .execute();
   }
 }

--- a/src/budget/budget.service.ts
+++ b/src/budget/budget.service.ts
@@ -1,0 +1,46 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CreateBudgetDto } from './dto/create-budget.dto';
+import { Budget } from './entities/budget.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from 'src/auth/entities/auth.entity';
+import { Repository } from 'typeorm';
+import { CategorieService } from 'src/categorie/categorie.service';
+import { Categorie } from 'src/categorie/entities/categorie.entity';
+
+@Injectable()
+export class BudgetService {
+  constructor(
+    @InjectRepository(Budget)
+    private budgetRepository: Repository<Budget>,
+    private categorieService: CategorieService,
+  ) {}
+  async saveBudget(
+    user: User,
+    createBudgetDto: CreateBudgetDto,
+  ): Promise<void> {
+    const categorieFind = await this.categorieService.findOne({
+      where: { title: createBudgetDto.title },
+    });
+
+    if (!categorieFind) {
+      throw new HttpException(
+        '카테고리가 존재하지 않습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    await this.save(user, categorieFind, createBudgetDto);
+  }
+
+  async save(
+    user: User,
+    categorieFind: Categorie,
+    createBudgetDto: CreateBudgetDto,
+  ) {
+    await this.budgetRepository.save({
+      user: { id: user.id },
+      categorie: { id: categorieFind.id },
+      amount: createBudgetDto.amount,
+    });
+  }
+}

--- a/src/budget/dto/create-budget.dto.ts
+++ b/src/budget/dto/create-budget.dto.ts
@@ -1,0 +1,9 @@
+import { IsNumber, IsString } from 'class-validator';
+import { CategorieType } from 'src/categorie/enum/categorie-type.enum';
+
+export class CreateBudgetDto {
+  @IsNumber()
+  amount: number;
+  @IsString()
+  title: CategorieType;
+}

--- a/src/budget/dto/update-budget.dto.ts
+++ b/src/budget/dto/update-budget.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateBudgetDto } from './create-budget.dto';
+
+export class UpdateBudgetDto extends PartialType(CreateBudgetDto) {}

--- a/src/budget/dto/update-budget.dto.ts
+++ b/src/budget/dto/update-budget.dto.ts
@@ -1,4 +1,8 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateBudgetDto } from './create-budget.dto';
+import { CategorieType } from 'src/categorie/enum/categorie-type.enum';
 
-export class UpdateBudgetDto extends PartialType(CreateBudgetDto) {}
+export class UpdateBudgetDto extends PartialType(CreateBudgetDto) {
+  title?: CategorieType;
+  amount?: number;
+}

--- a/src/budget/entities/budget.entity.ts
+++ b/src/budget/entities/budget.entity.ts
@@ -1,0 +1,36 @@
+import { User } from 'src/auth/entities/auth.entity';
+import { Categorie } from 'src/categorie/entities/categorie.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+} from 'typeorm';
+
+@Entity()
+export class Budget {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  amount: number;
+
+  @Column({ default: null })
+  period: string;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @ManyToOne(() => User, (user) => user.budget, { onDelete: 'CASCADE' })
+  user: User;
+
+  @ManyToOne(() => Categorie, (categorie) => categorie.budget, {
+    onDelete: 'CASCADE',
+  })
+  categorie: Categorie;
+}

--- a/src/categorie/categorie.controller.spec.ts
+++ b/src/categorie/categorie.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategorieController } from './categorie.controller';
+import { CategorieService } from './categorie.service';
+
+describe('CategorieController', () => {
+  let controller: CategorieController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategorieController],
+      providers: [CategorieService],
+    }).compile();
+
+    controller = module.get<CategorieController>(CategorieController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/categorie/categorie.controller.ts
+++ b/src/categorie/categorie.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { CategorieService } from './categorie.service';
+
+@Controller('categorie')
+export class CategorieController {
+  constructor(private readonly categorieService: CategorieService) {}
+}

--- a/src/categorie/categorie.controller.ts
+++ b/src/categorie/categorie.controller.ts
@@ -1,7 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
 import { CategorieService } from './categorie.service';
+import { AuthGuard } from '@nestjs/passport';
+import { Categorie } from './entities/categorie.entity';
 
-@Controller('categorie')
+@UseGuards(AuthGuard())
+@Controller('api/categorie')
 export class CategorieController {
   constructor(private readonly categorieService: CategorieService) {}
+
+  @Get()
+  async findAllCategorie(): Promise<Categorie[]> {
+    return await this.categorieService.findAllTitle();
+  }
 }

--- a/src/categorie/categorie.module.ts
+++ b/src/categorie/categorie.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CategorieService } from './categorie.service';
+import { CategorieController } from './categorie.controller';
+
+@Module({
+  controllers: [CategorieController],
+  providers: [CategorieService],
+})
+export class CategorieModule {}

--- a/src/categorie/categorie.module.ts
+++ b/src/categorie/categorie.module.ts
@@ -1,9 +1,17 @@
 import { Module } from '@nestjs/common';
 import { CategorieService } from './categorie.service';
 import { CategorieController } from './categorie.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Categorie } from './entities/categorie.entity';
+import { PassportModule } from '@nestjs/passport';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([Categorie]),
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+  ],
   controllers: [CategorieController],
   providers: [CategorieService],
+  exports: [CategorieService],
 })
 export class CategorieModule {}

--- a/src/categorie/categorie.service.spec.ts
+++ b/src/categorie/categorie.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategorieService } from './categorie.service';
+
+describe('CategorieService', () => {
+  let service: CategorieService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategorieService],
+    }).compile();
+
+    service = module.get<CategorieService>(CategorieService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/categorie/categorie.service.ts
+++ b/src/categorie/categorie.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CategorieService {}

--- a/src/categorie/categorie.service.ts
+++ b/src/categorie/categorie.service.ts
@@ -1,4 +1,30 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Categorie } from './entities/categorie.entity';
+import { FindOneOptions, Repository } from 'typeorm';
 
 @Injectable()
-export class CategorieService {}
+export class CategorieService {
+  constructor(
+    @InjectRepository(Categorie)
+    private categorieRepository: Repository<Categorie>,
+  ) {}
+
+  async findAllTitle(): Promise<Categorie[]> {
+    return await this.find({
+      select: ['title'],
+    });
+  }
+
+  async find(
+    options: FindOneOptions<Categorie>,
+  ): Promise<Categorie[] | undefined> {
+    return await this.categorieRepository.find(options);
+  }
+
+  async findOne(
+    options: FindOneOptions<Categorie>,
+  ): Promise<Categorie | undefined> {
+    return await this.categorieRepository.findOne(options);
+  }
+}

--- a/src/categorie/entities/categorie.entity.ts
+++ b/src/categorie/entities/categorie.entity.ts
@@ -4,8 +4,12 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
+  ManyToOne,
 } from 'typeorm';
 import { CategorieType } from '../enum/categorie-type.enum';
+import { User } from 'src/auth/entities/auth.entity';
+import { Budget } from 'src/budget/entities/budget.entity';
 
 @Entity()
 export class Categorie {
@@ -20,4 +24,7 @@ export class Categorie {
 
   @UpdateDateColumn()
   updated_at: Date;
+
+  @OneToMany(() => Budget, (budget) => budget.categorie, { cascade: true })
+  budget: Budget;
 }

--- a/src/categorie/entities/categorie.entity.ts
+++ b/src/categorie/entities/categorie.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CategorieType } from '../enum/categorie-type.enum';
+
+@Entity()
+export class Categorie {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: CategorieType;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+}

--- a/src/categorie/enum/categorie-type.enum.ts
+++ b/src/categorie/enum/categorie-type.enum.ts
@@ -1,0 +1,4 @@
+export enum CategorieType {
+  Food = 'Food',
+  Transport = 'Transport',
+}


### PR DESCRIPTION
## 🚀 이슈 번호
#3 예산 설정 및 설계 API 생성
<br>

## 💡 변경 이유
## B. 예산설정 및 설계

### 카테고리

- 카테고리는 `식비` , `교통` 등 일반적인 지출 카테고리를 의미합니다.
- 자유롭게 구성하여 생성하세요.

### 카테고리 목록(API)

- 유저가 예산설정에 사용할 수 있도록 모든 카테고리 목록을 반환합니다.

### 예산 설정(API)

- 해당 기간 별 설정한 `예산` 을 설정합니다. 예산은 `카테고리` 를 필수로 지정합니다.
    - ex) `식비` : 40만원, `교통` : 20만원
- 사용자는 언제든지 위 정보를 변경할 수 있습니다.

### 예산 설계 (=추천) (API)

- 카테고리 별 예산 설정에 어려움이 있는 사용자를 위해 예산 비율 추천 기능이 존재합니다.
- `카테고리` 지정 없이 총액 (ex. 100만원) 을 입력하면, `카테고리` 별 예산을 자동 생성합니다.
- 자동 생성된 예산은, 기존 이용중인 `유저` 들이 설정한 평균 값 입니다.
    - 유저들이 설정한 카테고리 별 예산을 통계하여, 평균적으로 40% 를 `식비`에, 30%를 `주거` 에 설정 하였다면 이에 맞게 추천.
    - 10% 이하의 카테고리들은 모두 묶어 `기타` 로 제공한다.(8% 문화, 7% 레져 라면 15% 기타로 표기)
    - **위 비율에 따라 금액이 입력됩니다.**
        - **ex) 식비 40만원, 주거 30만원, 취미 13만원 등.**
<br>

## 🔑 주요 변경사항

- 카테고리 목록 조회, 예산 설정 및 수정, 설계 API 생성

<br>

- 예산 설계 API 
1. 카테고리 테이블의 타이틀 별 총 예산 값 계산
2. 계산된 예산 값을 백분율로 변환
3. 입력 받은 amount 값을 각 타이틀의 백분율에 따라 할당

<br>

## 📷 테스트 결과

### API TEST
- 카테고리 목록 조회 API

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/7ad77c98-09e3-4208-accb-a8cc1e0cc8bf)

- 예산 설정 API

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/d9c8b18d-9b6c-4de6-bc1d-21e21403487f)

- 예산 설정 수정 API

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/b26292c6-53d7-4ccb-b2e9-1121be83cfa5)


- 예산 설계 API

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/c774c17f-7d06-46ff-8e24-e1f5492a805d)


