### PR TITLE
feat: 지출 기록 CRUD API 생성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { CategorieModule } from './categorie/categorie.module';
 import { BudgetModule } from './budget/budget.module';
+import { ExpenseModule } from './expense/expense.module';
 @Module({
   imports: [
     AuthModule,
@@ -22,11 +23,12 @@ import { BudgetModule } from './budget/budget.module';
         database: process.env.DB_NAME,
         entities: [__dirname + '/**/*.entity{.ts,.js}'],
         synchronize: true,
-        logging: true,
+        // logging: true,
       }),
     }),
     CategorieModule,
     BudgetModule,
+    ExpenseModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/entities/auth.entity.ts
+++ b/src/auth/entities/auth.entity.ts
@@ -1,3 +1,4 @@
+import { Expense } from 'src/expense/entities/expense.entity';
 import { Budget } from '../../budget/entities/budget.entity';
 import {
   Entity,
@@ -29,4 +30,7 @@ export class User {
 
   @OneToMany(() => Budget, (budget) => budget.user, { cascade: true })
   budget: Budget;
+
+  @OneToMany(() => Expense, (expense) => expense.user, { cascade: true })
+  expense: Expense;
 }

--- a/src/budget/budget.controller.ts
+++ b/src/budget/budget.controller.ts
@@ -13,12 +13,12 @@ import { User } from 'src/auth/entities/auth.entity';
 import { CreateBudgetDto } from './dto/create-budget.dto';
 import { UpdateBudgetDto } from './dto/update-budget.dto';
 
-@Controller('api')
+@Controller('api/budget')
 @UseGuards(AuthGuard())
 export class BudgetController {
   constructor(private readonly budgetService: BudgetService) {}
 
-  @Post('budget')
+  @Post()
   async setBudget(
     @GetUser() user: User,
     @Body() createBudgetDto: CreateBudgetDto,
@@ -29,7 +29,7 @@ export class BudgetController {
     };
   }
 
-  @Patch('budget/:id')
+  @Patch('/:id')
   async modifyBudget(
     @GetUser() user: User,
     @Param('id') id: number,
@@ -41,7 +41,7 @@ export class BudgetController {
     };
   }
 
-  @Post('budget/auto-distribute')
+  @Post('/auto-distribute')
   async autoDistributeBudget(
     @GetUser() user: User,
     @Body('amount') amount: number,

--- a/src/categorie/entities/categorie.entity.ts
+++ b/src/categorie/entities/categorie.entity.ts
@@ -5,11 +5,10 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   OneToMany,
-  ManyToOne,
 } from 'typeorm';
 import { CategorieType } from '../enum/categorie-type.enum';
-import { User } from 'src/auth/entities/auth.entity';
 import { Budget } from 'src/budget/entities/budget.entity';
+import { Expense } from 'src/expense/entities/expense.entity';
 
 @Entity()
 export class Categorie {
@@ -27,4 +26,7 @@ export class Categorie {
 
   @OneToMany(() => Budget, (budget) => budget.categorie, { cascade: true })
   budget: Budget;
+
+  @OneToMany(() => Expense, (expense) => expense.categorie, { cascade: true })
+  expense: Expense;
 }

--- a/src/expense/dto/create-expense.dto.ts
+++ b/src/expense/dto/create-expense.dto.ts
@@ -1,0 +1,16 @@
+import { IsDateString, IsNumber, IsString } from 'class-validator';
+import { CategorieType } from 'src/categorie/enum/categorie-type.enum';
+
+export class CreateExpenseDto {
+  @IsNumber()
+  amount: number;
+
+  @IsString()
+  title: CategorieType;
+
+  @IsString()
+  memo: string;
+
+  @IsDateString()
+  expense_date: Date;
+}

--- a/src/expense/dto/query-expense.dto.ts
+++ b/src/expense/dto/query-expense.dto.ts
@@ -16,8 +16,4 @@ export class ExpenseListQueryDto {
 
   @IsString()
   maxAmount: number;
-
-  @IsOptional()
-  @IsBoolean()
-  excludeTotal?: boolean;
 }

--- a/src/expense/dto/query-expense.dto.ts
+++ b/src/expense/dto/query-expense.dto.ts
@@ -1,0 +1,23 @@
+import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
+import { CategorieType } from 'src/categorie/enum/categorie-type.enum';
+
+export class ExpenseListQueryDto {
+  @IsString()
+  startDate: string;
+
+  @IsString()
+  endDate: string;
+
+  @IsString()
+  title: CategorieType;
+
+  @IsString()
+  minAmount: number;
+
+  @IsString()
+  maxAmount: number;
+
+  @IsOptional()
+  @IsBoolean()
+  excludeTotal?: boolean;
+}

--- a/src/expense/dto/sum-expense.dto.ts
+++ b/src/expense/dto/sum-expense.dto.ts
@@ -1,0 +1,6 @@
+export class ExpenseSummary {
+  constructor(
+    public totalAmount: number,
+    public categorySummaries: { category: string; amount: number }[],
+  ) {}
+}

--- a/src/expense/dto/update-expense.dto.ts
+++ b/src/expense/dto/update-expense.dto.ts
@@ -1,0 +1,8 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateExpenseDto } from './create-expense.dto';
+
+export class UpdateExpenseDto extends PartialType(CreateExpenseDto) {
+  amount?: number;
+  memo?: string;
+  expense_date?: Date;
+}

--- a/src/expense/entities/expense.entity.ts
+++ b/src/expense/entities/expense.entity.ts
@@ -1,0 +1,42 @@
+import { Categorie } from 'src/categorie/entities/categorie.entity';
+import { ExpenseModule } from '../expense.module';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from 'src/auth/entities/auth.entity';
+
+@Entity()
+export class Expense {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  expense_date: Date;
+
+  @Column()
+  amount: number;
+
+  @Column()
+  memo: string;
+
+  @Column({ default: false })
+  isExclud: boolean;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  updated_at: Date;
+
+  @ManyToOne(() => User, (user) => user.expense, { onDelete: 'CASCADE' })
+  user: User;
+  @ManyToOne(() => Categorie, (categorie) => categorie.expense, {
+    onDelete: 'CASCADE',
+  })
+  categorie: Categorie;
+}

--- a/src/expense/expense.controller.spec.ts
+++ b/src/expense/expense.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpenseController } from './expense.controller';
+import { ExpenseService } from './expense.service';
+
+describe('ExpenseController', () => {
+  let controller: ExpenseController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExpenseController],
+      providers: [ExpenseService],
+    }).compile();
+
+    controller = module.get<ExpenseController>(ExpenseController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/expense/expense.controller.ts
+++ b/src/expense/expense.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards,
+  Query,
+} from '@nestjs/common';
+import { ExpenseService } from './expense.service';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { AuthGuard } from '@nestjs/passport';
+import { GetUser } from 'src/auth/deco/get-user.decorator';
+import { User } from 'src/auth/entities/auth.entity';
+import { Expense } from './entities/expense.entity';
+import { ExpenseListQueryDto } from './dto/query-expense.dto';
+
+@Controller('api/expense')
+@UseGuards(AuthGuard())
+export class ExpenseController {
+  constructor(private readonly expenseService: ExpenseService) {}
+
+  @Post()
+  async createExpense(
+    @GetUser() user: User,
+    @Body() createExpenseDto: CreateExpenseDto,
+  ): Promise<any> {
+    await this.expenseService.saveExpense(user, createExpenseDto);
+    return {
+      message: '지출이 생성되었습니다.',
+    };
+  }
+
+  @Patch('/:id')
+  async modifyExpense(
+    @GetUser() user: User,
+    @Param('id') id: number,
+    @Body() updateExpenseDto: UpdateExpenseDto,
+  ): Promise<any> {
+    await this.expenseService.updateExpense(user, id, updateExpenseDto);
+    return {
+      message: '생성된 지출이 수정되었습니다.',
+    };
+  }
+
+  @Delete('/:id')
+  async deleteExpense(
+    @GetUser() user: User,
+    @Param('id') id: number,
+  ): Promise<any> {
+    await this.expenseService.removeExpense(user, id);
+    return {
+      message: '생성된 지출이 삭제되었습니다',
+    };
+  }
+
+  @Get('/:id')
+  async getExpenseDetail(
+    @GetUser() user: User,
+    @Param('id') id: number,
+  ): Promise<Expense> {
+    return await this.expenseService.findOneExpense(user, id);
+  }
+
+  @Get()
+  async getExpenseList(
+    @GetUser() user: User,
+    @Query() expenseListQueryDto: ExpenseListQueryDto,
+  ): Promise<any> {
+    return await this.expenseService.findExpense(user, expenseListQueryDto);
+  }
+}

--- a/src/expense/expense.module.ts
+++ b/src/expense/expense.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { ExpenseService } from './expense.service';
+import { ExpenseController } from './expense.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Expense } from './entities/expense.entity';
+import { PassportModule } from '@nestjs/passport';
+import { CategorieModule } from 'src/categorie/categorie.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Expense]),
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    CategorieModule,
+  ],
+  controllers: [ExpenseController],
+  providers: [ExpenseService],
+})
+export class ExpenseModule {}

--- a/src/expense/expense.service.spec.ts
+++ b/src/expense/expense.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExpenseService } from './expense.service';
+
+describe('ExpenseService', () => {
+  let service: ExpenseService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExpenseService],
+    }).compile();
+
+    service = module.get<ExpenseService>(ExpenseService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/expense/expense.service.ts
+++ b/src/expense/expense.service.ts
@@ -109,15 +109,13 @@ export class ExpenseService {
     const categorySummaries = new Map<string, number>();
 
     filteredExpenses.forEach((expense) => {
-      if (expense.categorie && expense.categorie.title) {
-        const categoryTitle = expense.categorie.title;
-        const amount = expense.amount;
+      const categoryTitle = expense.categorie.title;
+      const amount = expense.amount;
 
-        categorySummaries.set(
-          categoryTitle,
-          (categorySummaries.get(categoryTitle) || 0) + amount,
-        );
-      }
+      categorySummaries.set(
+        categoryTitle,
+        (categorySummaries.get(categoryTitle) || 0) + amount,
+      );
     });
 
     const categorySummariesArray = Array.from(categorySummaries).map(
@@ -129,11 +127,12 @@ export class ExpenseService {
 
     return new ExpenseSummary(totalAmount, categorySummariesArray);
   }
+
   async expensesQuery(
     expenseListQueryDto: ExpenseListQueryDto,
     user: User,
   ): Promise<Expense[]> {
-    const { startDate, endDate, title, minAmount, maxAmount, excludeTotal } =
+    const { startDate, endDate, title, minAmount, maxAmount } =
       expenseListQueryDto;
 
     const queryBuilder = this.expenseRepository

--- a/src/expense/expense.service.ts
+++ b/src/expense/expense.service.ts
@@ -1,0 +1,210 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CreateExpenseDto } from './dto/create-expense.dto';
+import { UpdateExpenseDto } from './dto/update-expense.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Expense } from './entities/expense.entity';
+import { FindOneOptions, Repository } from 'typeorm';
+import { User } from 'src/auth/entities/auth.entity';
+import { CategorieService } from 'src/categorie/categorie.service';
+import { Categorie } from 'src/categorie/entities/categorie.entity';
+import { ExpenseListQueryDto } from './dto/query-expense.dto';
+import { ExpenseSummary } from './dto/sum-expense.dto';
+
+@Injectable()
+export class ExpenseService {
+  constructor(
+    @InjectRepository(Expense)
+    private expenseRepository: Repository<Expense>,
+    private categorieService: CategorieService,
+  ) {}
+
+  async saveExpense(
+    user: User,
+    createExpenseDto: CreateExpenseDto,
+  ): Promise<void> {
+    const categorieFind = await this.categorieService.findOne({
+      where: { title: createExpenseDto.title },
+    });
+
+    if (!categorieFind) {
+      throw new HttpException(
+        '카테고리가 존재하지 않습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    await this.save(user, categorieFind, createExpenseDto);
+  }
+
+  async updateExpense(
+    user: User,
+    id: number,
+    updateExpenseDto: UpdateExpenseDto,
+  ): Promise<void> {
+    const expenseFind = await this.findOne({
+      where: {
+        id,
+        user: { id: user.id },
+      },
+    });
+
+    if (!expenseFind) {
+      throw new HttpException(
+        '생성한 지출을 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    await this.update(expenseFind, updateExpenseDto);
+  }
+
+  async removeExpense(user: User, id: number): Promise<void> {
+    const expenseFind = await this.findOne({
+      where: {
+        id,
+        user: { id: user.id },
+      },
+    });
+
+    if (!expenseFind) {
+      throw new HttpException(
+        '생성한 지출을 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    await this.remove(expenseFind);
+  }
+
+  async findOneExpense(user: User, id: number): Promise<Expense> {
+    const expenseFind = await this.findOne({
+      where: {
+        id,
+        user: { id: user.id },
+      },
+    });
+
+    if (!expenseFind) {
+      throw new HttpException(
+        '생성한 지출을 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    return expenseFind;
+  }
+
+  async findExpense(
+    user: User,
+    expenseListQueryDto: ExpenseListQueryDto,
+  ): Promise<ExpenseSummary> {
+    const expenses = await this.expensesQuery(expenseListQueryDto, user);
+
+    const filteredExpenses = expenses.filter((expense) => !expense.isExclud);
+
+    const totalAmount = filteredExpenses.reduce(
+      (total, expense) => total + expense.amount,
+      0,
+    );
+
+    const categorySummaries = new Map<string, number>();
+
+    filteredExpenses.forEach((expense) => {
+      if (expense.categorie && expense.categorie.title) {
+        const categoryTitle = expense.categorie.title;
+        const amount = expense.amount;
+
+        categorySummaries.set(
+          categoryTitle,
+          (categorySummaries.get(categoryTitle) || 0) + amount,
+        );
+      }
+    });
+
+    const categorySummariesArray = Array.from(categorySummaries).map(
+      ([category, amount]) => ({
+        category,
+        amount,
+      }),
+    );
+
+    return new ExpenseSummary(totalAmount, categorySummariesArray);
+  }
+  async expensesQuery(
+    expenseListQueryDto: ExpenseListQueryDto,
+    user: User,
+  ): Promise<Expense[]> {
+    const { startDate, endDate, title, minAmount, maxAmount, excludeTotal } =
+      expenseListQueryDto;
+
+    const queryBuilder = this.expenseRepository
+      .createQueryBuilder('expense')
+      .leftJoinAndSelect('expense.categorie', 'categorie')
+      .where('expense.user = :user', { user: user.id });
+
+    if (title) {
+      queryBuilder.andWhere('categorie.title = :title', { title });
+    }
+
+    if (startDate) {
+      queryBuilder.andWhere('expense.expense_date >= :startDate', {
+        startDate,
+      });
+    }
+
+    if (endDate) {
+      queryBuilder.andWhere('expense.expense_date <= :endDate', { endDate });
+    }
+
+    if (minAmount) {
+      queryBuilder.andWhere('expense.amount >= :minAmount', { minAmount });
+    }
+
+    if (maxAmount) {
+      queryBuilder.andWhere('expense.amount <= :maxAmount', { maxAmount });
+    }
+
+    return queryBuilder.getMany();
+  }
+
+  async find(options: FindOneOptions<Expense>): Promise<Expense[]> {
+    return await this.expenseRepository.find(options);
+  }
+
+  async findOne(options: FindOneOptions<Expense>): Promise<Expense> {
+    return await this.expenseRepository.findOne(options);
+  }
+
+  async update(
+    expenseFind: Expense,
+    updateExpenseDto: UpdateExpenseDto,
+  ): Promise<void> {
+    await this.expenseRepository
+      .createQueryBuilder()
+      .update(Expense)
+      .set({
+        amount: updateExpenseDto.amount,
+        memo: updateExpenseDto.memo,
+        expense_date: updateExpenseDto.expense_date,
+      })
+      .where('id = :id', { id: expenseFind.id })
+      .execute();
+  }
+
+  async remove(expenseFind: Expense): Promise<void> {
+    await this.expenseRepository.remove(expenseFind);
+  }
+
+  async save(
+    user: User,
+    categorieFind: Categorie,
+    createExpenseDto: CreateExpenseDto,
+  ): Promise<void> {
+    await this.expenseRepository.save({
+      user: { id: user.id },
+      categorie: { id: categorieFind.id },
+      amount: createExpenseDto.amount,
+      memo: createExpenseDto.memo,
+      expense_date: createExpenseDto.expense_date,
+    });
+  }
+}


### PR DESCRIPTION
## 🚀 이슈 번호
#5  지출 기록 및 CRUD API 생성
<br>

## 💡 변경 이유

### 지출

- `지출 일시`, `지출 금액`, `카테고리` 와 `메모` 를 입력하여 생성합니다
    - 추가적인 필드 자유롭게 사용

### 지출 CRUD (API)

- 지출을 `생성`, `수정`, `읽기(상세)`, `읽기(목록)`, `삭제` , `합계제외` 할 수 있습니다.
- `생성한 유저`만 위 권한을 가집니다.
- `읽기(목록)` 은 아래 기능을 가지고 있습니다.
    - 필수적으로 `기간` 으로 조회 합니다.
    - 조회된 모든 내용의 `지출 합계` , `카테고리 별 지출 합계` 를 같이 반환합니다.
    - 특정 `카테고리` 만 조회.
    - `최소` , `최대` 금액으로 조회.
        - ex) 0~10000원 / 20000원 ~ 100000원
- `합계제외` 처리한 지출은 목록에 포함되지만, 모든 `지출 합계`에서 제외됩니다.
<br>

## 🔑 주요 변경사항

- 지출 CRUD 생성
  - 지출 목록 조회 API
  1. 입력된 query를 통해 필터링을 한다.
  2. 합계 제외가 아닌 데이터만 조회한다. 
  3. 모든 지출 금액을 합산한다. (totalAmount )
  4.  Map을 사용하여 각 카테고리의 이름과 해당 카테고리에 대한 지출 총액을 저장한다.
  5. 해당 Map을 배열로 변환하여 returne 한다
  

<br>

## 📷 테스트 결과
### API TEST
- 지출 생성 API
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/dbfd9e88-bd8c-4f9c-b7fc-7767e93e9566)

- 지출 수정 API
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/c9b9f429-2121-47d1-be12-199cf2ed3a44)

- 지출 삭제 API
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/89491950-0a3a-4648-836f-0b1c1c971717)

- 지출 상세 조회API
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/0788536b-8aa9-410a-ac28-533a6ba4b34f)

- 지출 목록 조회API
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/d7ea60cd-f8f8-44c5-a5e5-60bde7a27bb4)
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/d97e5586-9513-45e9-a9b4-64c07c2dcea5)





