### PR TITLE
feat:지출 컨설팅(지출 추천, 안내)API 생성

### DIFF
--- a/src/budget/budget.module.ts
+++ b/src/budget/budget.module.ts
@@ -14,5 +14,6 @@ import { CategorieModule } from 'src/categorie/categorie.module';
   ],
   controllers: [BudgetController],
   providers: [BudgetService],
+  exports: [BudgetService],
 })
 export class BudgetModule {}

--- a/src/budget/entities/budget.entity.ts
+++ b/src/budget/entities/budget.entity.ts
@@ -17,9 +17,6 @@ export class Budget {
   @Column()
   amount: number;
 
-  @Column({ default: null })
-  period: string;
-
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/categorie/entities/categorie.entity.ts
+++ b/src/categorie/entities/categorie.entity.ts
@@ -18,6 +18,9 @@ export class Categorie {
   @Column()
   title: CategorieType;
 
+  @Column()
+  monthlyBudget: number;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/expense/consulting.service.ts
+++ b/src/expense/consulting.service.ts
@@ -1,0 +1,138 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { ExpenseService } from './expense.service';
+import { User } from 'src/auth/entities/auth.entity';
+import { BudgetService } from 'src/budget/budget.service';
+import { Expense } from './entities/expense.entity';
+import { Budget } from 'src/budget/entities/budget.entity';
+import { CategorieService } from 'src/categorie/categorie.service';
+
+@Injectable()
+export class ConsultingService {
+  constructor(
+    private expenseService: ExpenseService,
+    private budgetService: BudgetService,
+    private categorieService: CategorieService,
+  ) {}
+
+  async getTodaySummary(user: User) {
+    const today = new Date();
+    const todayDateString = today.toISOString().slice(0, 10);
+
+    const categories = await this.categorieService.find({});
+
+    const categoryBudgetMap = {};
+    categories.forEach((category) => {
+      categoryBudgetMap[category.title] = category.monthlyBudget / 30;
+    });
+
+    const todayExpenses = await this.expenseService.find({
+      where: {
+        user: { id: user.id },
+      },
+      relations: ['categorie'],
+    });
+
+    const summary = {
+      totalAmount: 0,
+      categorySummaries: {},
+    };
+
+    todayExpenses.forEach((expense) => {
+      const expenseDate = expense.expense_date.toISOString().slice(0, 10);
+
+      if (expenseDate === todayDateString) {
+        summary.totalAmount += expense.amount;
+        const categoryTitle = expense.categorie.title;
+
+        if (!summary.categorySummaries[categoryTitle]) {
+          summary.categorySummaries[categoryTitle] = {
+            totalAmount: 0,
+            expenses: [],
+          };
+        }
+
+        summary.categorySummaries[categoryTitle].totalAmount += expense.amount;
+        summary.categorySummaries[categoryTitle].expenses.push(expense);
+
+        const dailyBudget = categoryBudgetMap[categoryTitle];
+        const optimalAmount = dailyBudget;
+        const riskPercentage =
+          ((expense.amount - optimalAmount) / optimalAmount) * 100;
+        summary.categorySummaries[categoryTitle].optimalAmount = optimalAmount;
+        summary.categorySummaries[categoryTitle].riskPercentage =
+          riskPercentage;
+      }
+    });
+
+    return summary;
+  }
+
+  async generateRecommendation(user: User) {
+    const budgets = await this.budgetService.find({
+      where: { user: { id: user.id } },
+      relations: ['categorie'],
+    });
+
+    if (budgets.length === 0) {
+      throw new HttpException(
+        '예산이 존재하지 않습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+    const expenses = await this.expenseService.find({
+      where: { user: { id: user.id } },
+    });
+
+    const totalExpense = expenses.reduce(
+      (total, expense) => total + expense.amount,
+      0,
+    );
+
+    const totalBudget = budgets.reduce(
+      (total, budget) => total + budget.amount,
+      0,
+    );
+    const remainingBudget = totalBudget - totalExpense;
+
+    const categoryAmounts = this.calculateCategoryAmounts(budgets, expenses);
+    const userMessage = this.generateUserMessage(remainingBudget);
+
+    return {
+      totalAmount: remainingBudget,
+      categoryAmounts,
+      userMessage,
+    };
+  }
+
+  calculateCategoryAmounts(budgets: Budget[], expenses: Expense[]) {
+    const categoryAmounts: any[] = [];
+    for (const budget of budgets) {
+      const categoryExpenses = expenses.filter(
+        (expense) => expense.categorie === budget.categorie,
+      );
+      const categoryExpenseTotal = categoryExpenses.reduce(
+        (total, expense) => total + expense.amount,
+        0,
+      );
+      const remainingCategoryBudget = budget.amount - categoryExpenseTotal;
+
+      categoryAmounts.push({
+        category: budget.categorie,
+        amount: Math.max(remainingCategoryBudget, 0),
+      });
+    }
+    return categoryAmounts;
+  }
+
+  generateUserMessage(remainingBudget: number) {
+    let userMessage = '오늘 예산을 즐겁게 사용하세요!';
+    if (remainingBudget === 0) {
+      userMessage = '오늘 예산을 모두 사용했습니다. 조심히 지출하세요.';
+    } else if (remainingBudget < 1000) {
+      userMessage = '오늘은 조금만 사용하세요. 지출을 관리하세요!';
+    } else if (remainingBudget < 5000) {
+      userMessage = '잘 아끼고 있습니다! 오늘도 절약 도전!';
+    }
+    return userMessage;
+  }
+}

--- a/src/expense/expense.controller.ts
+++ b/src/expense/expense.controller.ts
@@ -17,11 +17,15 @@ import { GetUser } from 'src/auth/deco/get-user.decorator';
 import { User } from 'src/auth/entities/auth.entity';
 import { Expense } from './entities/expense.entity';
 import { ExpenseListQueryDto } from './dto/query-expense.dto';
+import { ConsultingService } from './consulting.service';
 
 @Controller('api/expense')
 @UseGuards(AuthGuard())
 export class ExpenseController {
-  constructor(private readonly expenseService: ExpenseService) {}
+  constructor(
+    private readonly expenseService: ExpenseService,
+    private readonly consultingService: ConsultingService,
+  ) {}
 
   @Post()
   async createExpense(
@@ -71,5 +75,15 @@ export class ExpenseController {
     @Query() expenseListQueryDto: ExpenseListQueryDto,
   ): Promise<any> {
     return await this.expenseService.findExpense(user, expenseListQueryDto);
+  }
+
+  @Get('/consulting/recommendation')
+  getRecommendation(@GetUser() user: User) {
+    return this.consultingService.generateRecommendation(user);
+  }
+
+  @Get('/consulting/today')
+  getTodayExpenses(@GetUser() user: User) {
+    return this.consultingService.getTodaySummary(user);
   }
 }

--- a/src/expense/expense.module.ts
+++ b/src/expense/expense.module.ts
@@ -5,14 +5,17 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Expense } from './entities/expense.entity';
 import { PassportModule } from '@nestjs/passport';
 import { CategorieModule } from 'src/categorie/categorie.module';
+import { ConsultingService } from './consulting.service';
+import { BudgetModule } from 'src/budget/budget.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Expense]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     CategorieModule,
+    BudgetModule,
   ],
   controllers: [ExpenseController],
-  providers: [ExpenseService],
+  providers: [ExpenseService, ConsultingService],
 })
 export class ExpenseModule {}


### PR DESCRIPTION
## 🚀 이슈 번호
#7 지출 컨설팅 API 생성
<br>

## 💡 변경 이유

## D. 지출 컨설팅

### 오늘 지출 추천(API)

- 설정한 `월별` 예산을 만족하기 위해 오늘 지출 가능한 금액을 `총액` 과 `카테고리 별 금액` 으로 제공합니다.
    - ex) 11월 9일 지출 가능 금액 총 30,000원, 식비 15,000 … 으로 페이지에 노출 예정.
- 고려사항 1. 앞선 일자에서 과다 소비하였다 해서 오늘 예산을 극히 줄이는것이 아니라, 이후 일자에 부담을 분배한다.
    - 앞선 일자에서 사용가능한 금액을 1만원 초과했다 하더라도, 오늘 예산이 1만원 주는것이 아닌 남은 기간 동안 분배해서 부담(10일 남았다면 1천원 씩).
- 고려사항 2. 기간 전체 예산을 초과 하더라도 `0원` 또는 `음수` 의 예산을 추천받지 않아야 한다.
    - 지속적인 소비 습관을 생성하기 위한 서비스이므로 예산을 초과하더라도 적정한 금액을 추천받아야 합니다.
    - `최소 금액`을 자유롭게 설정하세요.
- 유저의 상황에 맞는 1 문장의 `멘트` 노출.
    - 잘 아끼고 있을 때, 적당히 사용 중 일 때, 기준을 넘었을때, 예산을 초과하였을 때 등 유저의 상황에 맞는 메세지를 같이 노출합니다.
    - 조건과 기준은 자유롭게 설정하세요.
    - ex) “절약을 잘 실천하고 계세요! 오늘도 절약 도전!” 등
- 15333원 과 같은 값이라면 백원 단위 반올림 등으로 사용자 친화적이게 변환.
- **선택 구현 기능)** 매일 08:00 시 알림 발송
    - Scheduler 까지만 구현하셔도 좋습니다.
    - Discord webhook, 이메일, 카카오톡 등 실제 알림까지 진행하셔도 좋습니다.

### 오늘 지출 안내(API)

- 오늘 지출한 내용을 `총액` 과 `카테고리 별 금액` 을 알려줍니다.
- `월별`설정한 예산 기준 `카테고리 별` 통계 제공
    - 일자기준 오늘 `적정 금액` : 오늘 기준 사용했으면 적절했을 금액
    - 일자기준 오늘 `지출 금액` : 오늘 기준 사용한 금액
    - `위험도` : 카테고리 별 적정 금액, 지출금액의 차이를 위험도로 나타내며 %(퍼센테이지) 입니다.
        - ex) 오늘 사용하면 적당한 금액 10,000원/ 사용한 금액 20,000원 이면 200%
- **선택 구현 기능)** 매일 20:00 시 알림 발송
    - Scheduler 까지만 구현하셔도 좋습니다.
    - Discord webhook, 이메일, 카카오톡 등 실제 알림까지 진행하셔도 좋습니다.

> 본 기능은 명확한 요구사항이 존재하지 않습니다.위와 같이 유저들이 지속적으로 건강한 소비 습관을 생성하기 위한 목적을 이해하시고 자유롭게 해석 및 구현하세요.
>
<br>

## 🔑 주요 변경사항
 - 지출 컨설팅 API 생성
      - generateRecommendation 함수:
사용자의 예산과 지출 정보를 계산합니다.
사용자의 예산 정보와 지출 정보를 가져오고, 총 지출액과 총 예산액을 계산합니다.
calculateCategoryAmounts 함수를 호출하여 각 카테고리에 대한 남은 예산 정보를 가져옵니다.
사용자에게 제공될 메시지를 생성하는 generateUserMessage 함수를 호출합니다.
총 남은 예산 (totalAmount), 각 카테고리별 남은 예산 (categoryAmounts), 사용자에게 제공될 메시지 (userMessage)를 반환합니다.
     - calculateCategoryAmounts 함수:
각 카테고리에 대한 남은 예산을 계산합니다.
예산과 지출 정보를 사용하여 각 카테고리에 대한 남은 예산을 계산합니다.
남은 예산은 해당 카테고리의 예산에서 해당 카테고리의 지출 총액을 뺀 값으로 계산됩니다.
결과로 카테고리 이름과 해당 카테고리에 대한 남은 예산을 배열로 반환합니다.
     - generateUserMessage 함수:
남은 예산에 따라 사용자에게 메시지를 생성합니다.
예산에 따라 다양한 메시지를 생성하며, 예산이 0, 1000 미만, 5000 미만 등에 따라 다른 메시지를 반환합니다.
 - 오늘 지출 안내 API 생성
   - 현재 날짜와 오늘 날짜를 문자열로 설정합니다
   - 모든 카테고리의 월별 예산을 하루 평균으로 계산하여 categoryBudgetMap에 저장합니다. 
   - 사용자의 오늘 날짜에 해당하는 모든 지출 항목을 가져와 반복합니다.
   - 각 지출 항목에 대한 처리:
     1. 해당 카테고리의 이름을 가져옵니다,
     2.  이미 요약에 해당 카테고리가 없으면 초기화합니다.
     3.  현재 지출 항목을 해당 카테고리의 지출 목록에 추가합니다.
     4.  적정 금액과 위험도를 계산하여 해당 카테고리 정보에 추가합니다.
    - 모든 지출 항목을 처리한 후, summary를 반환합니다. summary에는 오늘의 총 지출 금액 (totalAmount) 및 카테고리별로 정리된 정보가 포함되어 있습니다.

<br>

## 📷 테스트 결과
### API TEST
- 오늘 지출 추천(API)
- 
![image](https://github.com/tomeee11/budget_management_system/assets/114478045/67b174ae-4275-4384-bdf1-1a416bb9b969)

- 오늘 지출 안내(API)

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/678ee370-e1ef-4fe4-8553-33b74f269a02)

