### PR TITLE
feat:지출 통계 API 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "date-fns": "^2.30.0",
         "mysql2": "^3.6.3",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "date-fns": "^2.30.0",
     "mysql2": "^3.6.3",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",

--- a/src/expense/dto/comparison-expense.dto.ts
+++ b/src/expense/dto/comparison-expense.dto.ts
@@ -1,0 +1,26 @@
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { ComparisonType } from '../enum/comparison-type .enum';
+
+export class ExpenseComparisonQueryDto {
+  @IsEnum(ComparisonType)
+  @IsNotEmpty()
+  type: ComparisonType;
+
+  @IsOptional()
+  @IsString()
+  startDate: string;
+
+  @IsOptional()
+  @IsString()
+  endDate: string;
+
+  @IsOptional()
+  @IsNumber()
+  otherUserId: number;
+}

--- a/src/expense/enum/comparison-type .enum.ts
+++ b/src/expense/enum/comparison-type .enum.ts
@@ -1,0 +1,5 @@
+export enum ComparisonType {
+  Month = 'month',
+  Day = 'day',
+  User = 'user',
+}

--- a/src/expense/expense.controller.ts
+++ b/src/expense/expense.controller.ts
@@ -18,6 +18,8 @@ import { User } from 'src/auth/entities/auth.entity';
 import { Expense } from './entities/expense.entity';
 import { ExpenseListQueryDto } from './dto/query-expense.dto';
 import { ConsultingService } from './consulting.service';
+import { ExpenseComparisonQueryDto } from './dto/comparison-expense.dto';
+import { StatisticsService } from './statistics.service';
 
 @Controller('api/expense')
 @UseGuards(AuthGuard())
@@ -25,6 +27,7 @@ export class ExpenseController {
   constructor(
     private readonly expenseService: ExpenseService,
     private readonly consultingService: ConsultingService,
+    private readonly statisticsService: StatisticsService,
   ) {}
 
   @Post()
@@ -85,5 +88,18 @@ export class ExpenseController {
   @Get('/consulting/today')
   getTodayExpenses(@GetUser() user: User) {
     return this.consultingService.getTodaySummary(user);
+  }
+
+  @Get('/type/statistics')
+  async getExpenseStatistics(
+    @GetUser() user: User,
+    @Query() expenseComparisonQueryDto: ExpenseComparisonQueryDto,
+  ): Promise<any> {
+    const statistics = await this.statisticsService.compareExpenses(
+      user,
+      expenseComparisonQueryDto,
+    );
+
+    return statistics;
   }
 }

--- a/src/expense/expense.module.ts
+++ b/src/expense/expense.module.ts
@@ -7,6 +7,7 @@ import { PassportModule } from '@nestjs/passport';
 import { CategorieModule } from 'src/categorie/categorie.module';
 import { ConsultingService } from './consulting.service';
 import { BudgetModule } from 'src/budget/budget.module';
+import { StatisticsService } from './statistics.service';
 
 @Module({
   imports: [
@@ -16,6 +17,6 @@ import { BudgetModule } from 'src/budget/budget.module';
     BudgetModule,
   ],
   controllers: [ExpenseController],
-  providers: [ExpenseService, ConsultingService],
+  providers: [ExpenseService, ConsultingService, StatisticsService],
 })
 export class ExpenseModule {}

--- a/src/expense/statistics.service.ts
+++ b/src/expense/statistics.service.ts
@@ -1,0 +1,168 @@
+import { Injectable } from '@nestjs/common';
+import { ExpenseService } from './expense.service';
+import { BudgetService } from 'src/budget/budget.service';
+import { CategorieService } from 'src/categorie/categorie.service';
+import { User } from 'src/auth/entities/auth.entity';
+import { ComparisonType } from './enum/comparison-type .enum';
+import { ExpenseComparisonQueryDto } from './dto/comparison-expense.dto';
+import { Between } from 'typeorm';
+import { addDays, endOfDay, startOfDay } from 'date-fns';
+import { Expense } from './entities/expense.entity';
+
+@Injectable()
+export class StatisticsService {
+  constructor(
+    private expenseService: ExpenseService,
+    private budgetService: BudgetService,
+    private categorieService: CategorieService,
+  ) {}
+
+  async compareExpenses(
+    user: User,
+    expenseComparisonQueryDto: ExpenseComparisonQueryDto,
+  ) {
+    if (expenseComparisonQueryDto.type === ComparisonType.Month) {
+      return await this.compareExpensesLastMonth(user);
+    } else if (expenseComparisonQueryDto.type === ComparisonType.Day) {
+      return await this.compareExpensesLastWeek(user);
+    }
+  }
+
+  async compareExpensesLastMonth(user: User) {
+    const today = new Date();
+
+    const currentMonthStart = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      1,
+    );
+
+    const currentExpenses = await this.fetchExpensesInDateRange(
+      user,
+      currentMonthStart,
+      today,
+    );
+
+    const lastMonthStart = new Date(currentMonthStart);
+    lastMonthStart.setMonth(currentMonthStart.getMonth() - 1);
+
+    const lastMonthToday = new Date(
+      today.getFullYear(),
+      today.getMonth() - 1,
+      today.getDate(),
+    );
+
+    const lastExpenses = await this.fetchExpensesInDateRange(
+      user,
+      lastMonthStart,
+      lastMonthToday,
+    );
+
+    const weeklyExpensesIncrease = await this.calculateExpenses(
+      currentExpenses,
+      lastExpenses,
+    );
+    return weeklyExpensesIncrease;
+  }
+
+  async compareExpensesLastWeek(user: User) {
+    const today = new Date();
+
+    const todayStartOfDay = startOfDay(today);
+    const todayEndOfDay = endOfDay(today);
+
+    const currentExpenses = await this.fetchExpensesInDateRange(
+      user,
+      todayStartOfDay,
+      todayEndOfDay,
+    );
+
+    const lastWeekStartDate = addDays(today, -7);
+
+    const lastWeekStartOfDay = startOfDay(lastWeekStartDate);
+    const lastWeekEndOfDay = endOfDay(lastWeekStartDate);
+
+    const lastExpenses = await this.fetchExpensesInDateRange(
+      user,
+      lastWeekStartOfDay,
+      lastWeekEndOfDay,
+    );
+
+    const dayOfWeekNumber = today.getDay();
+    const dayOfWeekString = this.getDayOfWeekString(dayOfWeekNumber);
+
+    const weeklyExpensesIncrease = await this.calculateExpensesIncrease(
+      currentExpenses,
+      lastExpenses,
+    );
+
+    return {
+      [dayOfWeekString]: weeklyExpensesIncrease,
+    };
+  }
+
+  calculateExpensesIncrease(
+    currentExpenses: Expense[],
+    lastExpenses: Expense[],
+  ) {
+    const currentTotal = currentExpenses.reduce(
+      (acc, expense) => acc + expense.amount,
+      0,
+    );
+    const lastTotal = lastExpenses.reduce(
+      (acc, expense) => acc + expense.amount,
+      0,
+    );
+
+    const percentageIncrease = ((currentTotal - lastTotal) / lastTotal) * 100;
+
+    return `${percentageIncrease}%`;
+  }
+
+  async calculateExpenses(
+    currentExpenses: Expense[],
+    lastExpenses: Expense[],
+  ): Promise<{ [categoryTitle: string]: string }> {
+    const result: { [categoryTitle: string]: string } = {};
+
+    for (const expense of currentExpenses) {
+      const categoryTitle = expense.categorie.title;
+      const amount = expense.amount;
+
+      if (!result[categoryTitle]) {
+        result[categoryTitle] = '';
+      }
+
+      if (lastExpenses.some((e) => e.categorie.title === categoryTitle)) {
+        const lastMonthAmount = lastExpenses.find(
+          (e) => e.categorie.title === categoryTitle,
+        )?.amount;
+
+        const percentage =
+          lastMonthAmount && lastMonthAmount !== 0
+            ? `${Math.round((amount / lastMonthAmount) * 100)}%`
+            : '100%';
+
+        result[categoryTitle] = `${categoryTitle} 지난달 대비 ${percentage}`;
+      }
+    }
+
+    return result;
+  }
+
+  getDayOfWeekString(dayOfWeek: number): string {
+    const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+    return daysOfWeek[dayOfWeek];
+  }
+
+  async fetchExpensesInDateRange(user: User, startDate: Date, endDate: Date) {
+    return await this.expenseService.find({
+      where: {
+        user: { id: user.id },
+        expense_date: Between(startDate, endDate),
+      },
+
+      relations: ['categorie'],
+    });
+  }
+}


### PR DESCRIPTION
## 🚀 이슈 번호
#9  지출 통계 API 생성
<br>

## 💡 변경 이유

### 지출 통계 (API)

- `지난 달` 대비 `총액`, `카테고리 별` 소비율.
    - 오늘이 10일차 라면, 지난달 10일차 까지의 데이터를 대상으로 비교
    - ex) `식비` 지난달 대비 150%
- `지난 요일` 대비 소비율
    - 오늘이 `월요일` 이라면 지난 `월요일` 에 소비한 모든 기록 대비 소비율
    - ex) `월요일` 평소 대비 80%

<br>

## 🔑 주요 변경사항
 - 지난 달 대비, 지난 요일 대비 중복되는 코드가 많아
 코드를 분할하여 중복성을 최소화, 및 Date를 다루다보니 지저분해질 수 있는 코드를
 date-fns를 이용하여 간단하게 표현
<br>

## 📷 테스트 결과

### API TEST
- 지난 달 대비

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/83a9c0bf-5df6-4847-9cc9-ef06f1be52eb)

- 지난 요일 대비 

![image](https://github.com/tomeee11/budget_management_system/assets/114478045/4a1a5efe-4e9a-4037-b123-b6eeda6d9237)
